### PR TITLE
Refine the auron build for IDEA developer friendly

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -25,15 +25,10 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.apache.auron</groupId>
-  <artifactId>spark-version-annotation-macros_${scalaVersion}</artifactId>
+  <artifactId>auron-common_${scalaVersion}</artifactId>
   <packaging>jar</packaging>
 
   <dependencies>
-    <dependency>
-      <groupId>org.apache.auron</groupId>
-      <artifactId>auron-common_${scalaVersion}</artifactId>
-      <version>${project.version}</version>
-    </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
@@ -47,6 +42,11 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scalaVersion}</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -66,35 +66,22 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>${maven.plugin.templating.version}</version>
+        <executions>
+          <execution>
+            <id>filter-src</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>src/main/templates</sourceDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>scala-2.12</id>
-      <activation>
-        <property>
-          <name>scalaVersion</name>
-          <value>2.12</value>
-        </property>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.scalamacros</groupId>
-          <artifactId>paradise_${scalaLongVersion}</artifactId>
-          <version>${scalamacros.paradise.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>org.scala-lang</groupId>
-              <artifactId>scala-compiler</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>org.scala-lang</groupId>
-              <artifactId>scala-reflect</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/common/src/main/scala/org/apache/auron/util/SemanticVersion.scala
+++ b/common/src/main/scala/org/apache/auron/util/SemanticVersion.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.auron.util
+package org.apache.auron.util
 
 /**
  * Encapsulate a component version for the convenience of version checks.

--- a/common/src/main/templates/org/apache/auron/common/ProjectConstants.java
+++ b/common/src/main/templates/org/apache/auron/common/ProjectConstants.java
@@ -18,5 +18,5 @@
 package org.apache.auron.common;
 public final class ProjectConstants {
 	public static final String PROJECT_VERSION = "${project.version}";
-	public static final String SPARK_BINARY_VERSION = "${sparkBinaryVersion}";
+	public static final String SHIM_NAME = "${shimName}";
 }

--- a/common/src/main/templates/org/apache/auron/common/ProjectConstants.java
+++ b/common/src/main/templates/org/apache/auron/common/ProjectConstants.java
@@ -14,17 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.auron.util
 
-import org.apache.spark.SPARK_VERSION
-
-object AuronTestUtils {
-
-  lazy val SPARK_RUNTIME_VERSION: SemanticVersion = SemanticVersion(SPARK_VERSION)
-  lazy val isSparkV30OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.0"
-  lazy val isSparkV31OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.1"
-  lazy val isSparkV32OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.2"
-  lazy val isSparkV33OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.3"
-  lazy val isSparkV34OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.4"
-  lazy val isSparkV35OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.5"
+package org.apache.auron.common;
+public final class ProjectConstants {
+	public static final String PROJECT_VERSION = "${project.version}";
+	public static final String SPARK_BINARY_VERSION = "${sparkBinaryVersion}";
 }

--- a/common/src/main/templates/org/apache/auron/common/ProjectConstants.java
+++ b/common/src/main/templates/org/apache/auron/common/ProjectConstants.java
@@ -16,6 +16,7 @@
  */
 
 package org.apache.auron.common;
+
 public final class ProjectConstants {
 	public static final String PROJECT_VERSION = "${project.version}";
 	public static final String SHIM_NAME = "${shimName}";

--- a/common/src/test/scala/org/apache/auron/util/AuronTestUtils.scala
+++ b/common/src/test/scala/org/apache/auron/util/AuronTestUtils.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.util
+
+import org.apache.spark.SPARK_VERSION
+
+object AuronTestUtils {
+  lazy val SPARK_RUNTIME_VERSION: SemanticVersion = SemanticVersion(SPARK_VERSION)
+  lazy val isSparkV30OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.0"
+  lazy val isSparkV31OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.1"
+  lazy val isSparkV32OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.2"
+  lazy val isSparkV33OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.3"
+  lazy val isSparkV34OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.4"
+  lazy val isSparkV35OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.5"
+}

--- a/common/src/test/scala/org/apache/auron/util/AuronTestUtils.scala
+++ b/common/src/test/scala/org/apache/auron/util/AuronTestUtils.scala
@@ -19,6 +19,7 @@ package org.apache.auron.util
 import org.apache.spark.SPARK_VERSION
 
 object AuronTestUtils {
+
   lazy val SPARK_RUNTIME_VERSION: SemanticVersion = SemanticVersion(SPARK_VERSION)
   lazy val isSparkV30OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.0"
   lazy val isSparkV31OrGreater: Boolean = SPARK_RUNTIME_VERSION >= "3.1"

--- a/dev/mvn-build-helper/assembly/pom.xml
+++ b/dev/mvn-build-helper/assembly/pom.xml
@@ -37,6 +37,11 @@
       <artifactId>spark-extension_${scalaVersion}</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.auron</groupId>
+      <artifactId>${shimPkg}_${scalaVersion}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -120,7 +125,7 @@
               <archive>
                 <addMavenDescriptor>false</addMavenDescriptor>
               </archive>
-              <outputFile>../../../target/auron-spark-${sparkBinaryVersion}_${scalaVersion}-${releaseMode}-${os.detected.classifier}-${project.version}.jar</outputFile>
+              <outputFile>../../../target/auron-${shimName}_${scalaVersion}-${releaseMode}-${os.detected.classifier}-${project.version}.jar</outputFile>
             </configuration>
           </execution>
         </executions>
@@ -137,67 +142,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>spark-3.0</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.auron</groupId>
-          <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>spark-3.1</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.auron</groupId>
-          <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>spark-3.2</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.auron</groupId>
-          <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>spark-3.3</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.auron</groupId>
-          <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>spark-3.4</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.auron</groupId>
-          <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>spark-3.5</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.auron</groupId>
-          <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
-    </profile>
-
     <profile>
       <id>celeborn</id>
       <dependencies>

--- a/dev/mvn-build-helper/assembly/pom.xml
+++ b/dev/mvn-build-helper/assembly/pom.xml
@@ -37,11 +37,6 @@
       <artifactId>spark-extension_${scalaVersion}</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.auron</groupId>
-      <artifactId>${shimPkg}_${scalaVersion}</artifactId>
-      <version>${project.version}</version>
-    </dependency>
   </dependencies>
 
   <build>
@@ -125,7 +120,7 @@
               <archive>
                 <addMavenDescriptor>false</addMavenDescriptor>
               </archive>
-              <outputFile>../../../target/auron-${shimName}_${scalaVersion}-${releaseMode}-${os.detected.classifier}-${project.version}.jar</outputFile>
+              <outputFile>../../../target/auron-spark-${sparkBinaryVersion}_${scalaVersion}-${releaseMode}-${os.detected.classifier}-${project.version}.jar</outputFile>
             </configuration>
           </execution>
         </executions>
@@ -142,6 +137,67 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>spark-3.0</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.auron</groupId>
+          <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>spark-3.1</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.auron</groupId>
+          <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>spark-3.2</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.auron</groupId>
+          <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>spark-3.3</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.auron</groupId>
+          <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>spark-3.4</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.auron</groupId>
+          <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>spark-3.5</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.auron</groupId>
+          <artifactId>spark-extension-shims-spark3_${scalaVersion}</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+
     <profile>
       <id>celeborn</id>
       <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <module>common</module>
     <module>spark-version-annotation-macros</module>
     <module>spark-extension</module>
+    <module>${shimPkg}</module>
     <module>hadoop-shim</module>
     <module>dev/mvn-build-helper/assembly</module>
     <module>dev/mvn-build-helper/proto</module>
@@ -457,79 +458,67 @@
 
     <profile>
       <id>spark-3.0</id>
-      <modules>
-        <module>spark-extension-shims-spark3</module>
-      </modules>
       <properties>
+        <shimName>spark-3.0</shimName>
+        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <scalaTestVersion>3.0.8</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.0.3</sparkVersion>
-        <sparkBinaryVersion>3.0</sparkBinaryVersion>
       </properties>
     </profile>
 
     <profile>
       <id>spark-3.1</id>
-      <modules>
-        <module>spark-extension-shims-spark3</module>
-      </modules>
       <properties>
+        <shimName>spark-3.1</shimName>
+        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.1.3</sparkVersion>
-        <sparkBinaryVersion>3.1</sparkBinaryVersion>
       </properties>
     </profile>
 
     <profile>
       <id>spark-3.2</id>
-      <modules>
-        <module>spark-extension-shims-spark3</module>
-      </modules>
       <properties>
+        <shimName>spark-3.2</shimName>
+        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.2.4</sparkVersion>
-        <sparkBinaryVersion>3.2</sparkBinaryVersion>
       </properties>
     </profile>
 
     <profile>
       <id>spark-3.3</id>
-      <modules>
-        <module>spark-extension-shims-spark3</module>
-      </modules>
       <properties>
+        <shimName>spark-3.3</shimName>
+        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.3.4</sparkVersion>
-        <sparkBinaryVersion>3.3</sparkBinaryVersion>
       </properties>
     </profile>
 
     <profile>
       <id>spark-3.4</id>
-      <modules>
-        <module>spark-extension-shims-spark3</module>
-      </modules>
       <properties>
+        <shimName>spark-3.4</shimName>
+        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.4.4</sparkVersion>
-        <sparkBinaryVersion>3.4</sparkBinaryVersion>
       </properties>
     </profile>
 
     <profile>
       <id>spark-3.5</id>
-      <modules>
-        <module>spark-extension-shims-spark3</module>
-      </modules>
       <properties>
+        <shimName>spark-3.5</shimName>
+        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.5.6</sparkVersion>
-        <sparkBinaryVersion>3.5</sparkBinaryVersion>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <maven.plugin.surefire.version>3.3.0</maven.plugin.surefire.version>
     <maven.plugin.shade.version>3.5.2</maven.plugin.shade.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
-    <maven.plugin.templating.version>1.0.0</maven.plugin.templating.version>
+    <maven.plugin.templating.version>3.0.0</maven.plugin.templating.version>
 
     <scalamacros.paradise.version>2.1.1</scalamacros.paradise.version>
     <semanticdb.version>4.8.1</semanticdb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,9 @@
   <packaging>pom</packaging>
 
   <modules>
+    <module>common</module>
     <module>spark-version-annotation-macros</module>
     <module>spark-extension</module>
-    <module>${shimPkg}</module>
     <module>hadoop-shim</module>
     <module>dev/mvn-build-helper/assembly</module>
     <module>dev/mvn-build-helper/proto</module>
@@ -56,6 +56,7 @@
     <maven.plugin.surefire.version>3.3.0</maven.plugin.surefire.version>
     <maven.plugin.shade.version>3.5.2</maven.plugin.shade.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
+    <maven.plugin.templating.version>1.0.0</maven.plugin.templating.version>
 
     <scalamacros.paradise.version>2.1.1</scalamacros.paradise.version>
     <semanticdb.version>4.8.1</semanticdb.version>
@@ -226,9 +227,6 @@
           <args>
             <arg>-Ywarn-unused</arg>
           </args>
-          <jvmArgs>
-            <jvmArg>-Dauron.shim=${shimName}</jvmArg>
-          </jvmArgs>
         </configuration>
         <dependencies>
           <dependency>
@@ -459,67 +457,79 @@
 
     <profile>
       <id>spark-3.0</id>
+      <modules>
+        <module>spark-extension-shims-spark3</module>
+      </modules>
       <properties>
-        <shimName>spark-3.0</shimName>
-        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <scalaTestVersion>3.0.8</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.0.3</sparkVersion>
+        <sparkBinaryVersion>3.0</sparkBinaryVersion>
       </properties>
     </profile>
 
     <profile>
       <id>spark-3.1</id>
+      <modules>
+        <module>spark-extension-shims-spark3</module>
+      </modules>
       <properties>
-        <shimName>spark-3.1</shimName>
-        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.1.3</sparkVersion>
+        <sparkBinaryVersion>3.1</sparkBinaryVersion>
       </properties>
     </profile>
 
     <profile>
       <id>spark-3.2</id>
+      <modules>
+        <module>spark-extension-shims-spark3</module>
+      </modules>
       <properties>
-        <shimName>spark-3.2</shimName>
-        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.2.4</sparkVersion>
+        <sparkBinaryVersion>3.2</sparkBinaryVersion>
       </properties>
     </profile>
 
     <profile>
       <id>spark-3.3</id>
+      <modules>
+        <module>spark-extension-shims-spark3</module>
+      </modules>
       <properties>
-        <shimName>spark-3.3</shimName>
-        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.3.4</sparkVersion>
+        <sparkBinaryVersion>3.3</sparkBinaryVersion>
       </properties>
     </profile>
 
     <profile>
       <id>spark-3.4</id>
+      <modules>
+        <module>spark-extension-shims-spark3</module>
+      </modules>
       <properties>
-        <shimName>spark-3.4</shimName>
-        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.4.4</sparkVersion>
+        <sparkBinaryVersion>3.4</sparkBinaryVersion>
       </properties>
     </profile>
 
     <profile>
       <id>spark-3.5</id>
+      <modules>
+        <module>spark-extension-shims-spark3</module>
+      </modules>
       <properties>
-        <shimName>spark-3.5</shimName>
-        <shimPkg>spark-extension-shims-spark3</shimPkg>
         <scalaTestVersion>3.2.9</scalaTestVersion>
         <scalafmtVersion>3.0.0</scalafmtVersion>
         <sparkVersion>3.5.6</sparkVersion>
+        <sparkBinaryVersion>3.5</sparkBinaryVersion>
       </properties>
     </profile>
 

--- a/spark-extension-shims-spark3/pom.xml
+++ b/spark-extension-shims-spark3/pom.xml
@@ -31,6 +31,11 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.auron</groupId>
+      <artifactId>auron-common_${scalaVersion}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.auron</groupId>
       <artifactId>spark-extension_${scalaVersion}</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -93,6 +98,12 @@
       <version>1.12.10</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.auron</groupId>
+      <artifactId>auron-common_${scalaVersion}</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+    </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scalaVersion}</artifactId>

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/AuronFunctionSuite.scala
@@ -17,7 +17,8 @@
 package org.apache.spark.sql.auron
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.auron.util.AuronTestUtils
+
+import org.apache.auron.util.AuronTestUtils
 
 class AuronFunctionSuite extends org.apache.spark.sql.QueryTest with BaseAuronSQLSuite {
 

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/AuronQuerySuite.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.auron
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.auron.util.AuronTestUtils
+
+import org.apache.auron.util.AuronTestUtils
 
 class AuronQuerySuite
     extends org.apache.spark.sql.QueryTest

--- a/spark-version-annotation-macros/pom.xml
+++ b/spark-version-annotation-macros/pom.xml
@@ -51,24 +51,6 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>prepare-test-jar</id>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-            <phase>test-compile</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
   <profiles>
     <profile>
       <id>scala-2.12</id>

--- a/spark-version-annotation-macros/src/main/scala/org/apache/auron/sparkver.scala
+++ b/spark-version-annotation-macros/src/main/scala/org/apache/auron/sparkver.scala
@@ -23,10 +23,10 @@ import scala.reflect.macros.whitebox
 
 object sparkver {
   def matchVersion(vers: String): Boolean = {
-    val configuredVer = System.getProperty("auron.shim")
     for (ver <- vers.split("/")) {
       val verStripped = ver.trim
-      if (s"spark-$verStripped" == configuredVer) {
+      // please ensure the common module is built
+      if (verStripped == org.apache.auron.common.ProjectConstants.SPARK_BINARY_VERSION) {
         return true
       }
     }

--- a/spark-version-annotation-macros/src/main/scala/org/apache/auron/sparkver.scala
+++ b/spark-version-annotation-macros/src/main/scala/org/apache/auron/sparkver.scala
@@ -23,10 +23,11 @@ import scala.reflect.macros.whitebox
 
 object sparkver {
   def matchVersion(vers: String): Boolean = {
+    // please ensure the common module is built
+    val configuredVer = org.apache.auron.common.ProjectConstants.SHIM_NAME
     for (ver <- vers.split("/")) {
       val verStripped = ver.trim
-      // please ensure the common module is built
-      if (verStripped == org.apache.auron.common.ProjectConstants.SPARK_BINARY_VERSION) {
+      if (s"spark-$verStripped" == configuredVer) {
         return true
       }
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
before, the scala-maven-plugin rely the `auron.shim` system properties.

For IDEA, the system property can not be transferred to the scala-maven-plugin even with the related profile activated.

For IDEA developer, they have to set the `auron.shim` manually.  
<img width="981" height="707" alt="image" src="https://github.com/user-attachments/assets/bfd898a8-99c9-4bce-b130-4ed7ebf23c73" />

It is not friendly.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

In this PR, we use the `templating-maven-plugin` instead of system property.


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes, developer need to build the common module when switching spark version.

# How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

GA.
