### PR TITLE
Introduce datafusion-spark crate to support some math functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ datafusion-ext-plans = { path = "./native-engine/datafusion-ext-plans" }
 datafusion = { version = "49.0.0" }
 datafusion-datasource = { version = "49.0.0" }
 datafusion-datasource-parquet = { version = "49.0.0" }
+datafusion-spark = { version = "49.0.0" }
 
 # orc-rust branch=v0.6.0-auron
 orc-rust = { version = "0.6.0" }
@@ -115,6 +116,7 @@ datafusion-datasource-parquet = { git = "https://github.com/blaze-init/arrow-dat
 datafusion-execution = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "9034aeffb"}
 datafusion-optimizer = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "9034aeffb"}
 datafusion-physical-expr = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "9034aeffb"}
+datafusion-spark = { git = "https://github.com/blaze-init/arrow-datafusion.git", rev = "9034aeffb"}
 orc-rust = { git = "https://github.com/blaze-init/datafusion-orc.git", rev = "e10b240"}
 
 # arrow: branch=v53-auron

--- a/native-engine/auron-serde/Cargo.toml
+++ b/native-engine/auron-serde/Cargo.toml
@@ -30,6 +30,7 @@ datafusion-ext-commons = { workspace = true }
 datafusion-ext-exprs = { workspace = true }
 datafusion-ext-functions = { workspace = true }
 datafusion-ext-plans = { workspace = true }
+datafusion-spark = { workspace = true }
 
 base64 = { workspace = true }
 log = { workspace = true }

--- a/native-engine/auron-serde/proto/auron.proto
+++ b/native-engine/auron-serde/proto/auron.proto
@@ -253,7 +253,7 @@ enum ScalarFunction {
   StartsWith=51;
   Strpos=52;
   Substr=53;
-  ToHex=54;
+  // ToHex=54;
   ToTimestamp=55;
   ToTimestampMillis=56;
   ToTimestampMicros=57;
@@ -263,6 +263,9 @@ enum ScalarFunction {
   Trim=61;
   Upper=62;
   Coalesce=63;
+  Expm1=64;
+  Factorial=65;
+  Hex=66;
   SparkExtFunctions=10000;
 }
 

--- a/native-engine/auron-serde/src/from_proto.rs
+++ b/native-engine/auron-serde/src/from_proto.rs
@@ -755,6 +755,7 @@ impl From<&protobuf::BoundReference> for Column {
 impl From<protobuf::ScalarFunction> for Arc<ScalarUDF> {
     fn from(f: protobuf::ScalarFunction) -> Self {
         use datafusion::functions as f;
+        use datafusion_spark::function as spark_fun;
         use protobuf::ScalarFunction;
 
         match f {
@@ -814,13 +815,20 @@ impl From<protobuf::ScalarFunction> for Arc<ScalarUDF> {
             ScalarFunction::StartsWith => f::string::starts_with(),
             ScalarFunction::Strpos => f::unicode::strpos(),
             ScalarFunction::Substr => f::unicode::substr(),
-            ScalarFunction::ToHex => f::string::to_hex(),
+            // ScalarFunction::ToHex => f::string::to_hex(),
             ScalarFunction::ToTimestampMicros => f::datetime::to_timestamp_micros(),
             ScalarFunction::ToTimestampSeconds => f::datetime::to_timestamp_seconds(),
             ScalarFunction::Now => f::datetime::now(),
             ScalarFunction::Translate => f::unicode::translate(),
             ScalarFunction::RegexpMatch => f::regex::regexp_match(),
             ScalarFunction::Coalesce => f::core::coalesce(),
+
+            // -- datafusion-spark functions
+            // math functions
+            ScalarFunction::Expm1 => spark_fun::math::expm1(),
+            ScalarFunction::Factorial => spark_fun::math::factorial(),
+            ScalarFunction::Hex => spark_fun::math::hex(),
+
             ScalarFunction::SparkExtFunctions => {
                 unreachable!()
             }

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/AuronFunctionSuite.scala
@@ -20,7 +20,10 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.auron.util.AuronTestUtils
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 
-class AuronFunctionSuite extends org.apache.spark.sql.QueryTest with BaseAuronSQLSuite with AdaptiveSparkPlanHelper {
+class AuronFunctionSuite
+    extends org.apache.spark.sql.QueryTest
+    with BaseAuronSQLSuite
+    with AdaptiveSparkPlanHelper {
 
   test("sum function with float input") {
     if (AuronTestUtils.isSparkV31OrGreater) {

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/AuronFunctionSuite.scala
@@ -18,8 +18,9 @@ package org.apache.spark.sql.auron
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.auron.util.AuronTestUtils
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 
-class AuronFunctionSuite extends org.apache.spark.sql.QueryTest with BaseAuronSQLSuite {
+class AuronFunctionSuite extends org.apache.spark.sql.QueryTest with BaseAuronSQLSuite with AdaptiveSparkPlanHelper {
 
   test("sum function with float input") {
     if (AuronTestUtils.isSparkV31OrGreater) {
@@ -66,6 +67,33 @@ class AuronFunctionSuite extends org.apache.spark.sql.QueryTest with BaseAuronSQ
           |""".stripMargin
       val df = sql(functions)
       checkAnswer(df, Seq(Row(-222940379)))
+    }
+  }
+
+  test("expm1 function") {
+    withTable("t1") {
+      sql("create table t1(c1 double) using parquet")
+      sql("insert into t1 values(0.0), (1.1), (2.2)")
+      val df = sql("select expm1(c1) from t1")
+      checkAnswer(df, Seq(Row(0.0), Row(2.0041660239464334), Row(8.025013499434122)))
+    }
+  }
+
+  test("factorial function") {
+    withTable("t1") {
+      sql("create table t1(c1 int) using parquet")
+      sql("insert into t1 values(5)")
+      val df = sql("select factorial(c1) from t1")
+      checkAnswer(df, Seq(Row(120)))
+    }
+  }
+
+  test("hex function") {
+    withTable("t1") {
+      sql("create table t1(c1 int, c2 string) using parquet")
+      sql("insert into t1 values(17, 'Spark SQL')")
+      val df = sql("select hex(c1), hex(c2) from t1")
+      checkAnswer(df, Seq(Row("11", "537061726B2053514C")))
     }
   }
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -35,7 +35,7 @@ import org.apache.commons.lang3.reflect.MethodUtils
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.auron.util.Using
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Abs, Acos, Add, Alias, And, Asin, Atan, Attribute, AttributeReference, BitwiseAnd, BitwiseOr, BoundReference, CaseWhen, Cast, Ceil, CheckOverflow, Coalesce, Concat, ConcatWs, Contains, Cos, CreateArray, CreateNamedStruct, DayOfMonth, Divide, EndsWith, EqualTo, Exp, Expm1, Expression, Factorial, Floor, GetArrayItem, GetJsonObject, GetMapValue, GetStructField, GreaterThan, GreaterThanOrEqual, Hex, If, In, InSet, IsNotNull, IsNull, LeafExpression, Length, LessThan, LessThanOrEqual, Like, Literal, Log, Log10, Log2, Lower, MakeDecimal, Md5, Month, Multiply, Murmur3Hash, Not, NullIf, OctetLength, Or, Remainder, Sha2, ShiftLeft, ShiftRight, Signum, Sin, Sqrt, StartsWith, StringRepeat, StringSpace, StringTrim, StringTrimLeft, StringTrimRight, Substring, Subtract, Tan, Unevaluable, UnscaledValue, Upper, XxHash64, Year}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, Average, CollectList, CollectSet, Count, DeclarativeAggregate, First, Max, Min, Sum, TypedImperativeAggregate}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.expressions.codegen.ExprCode

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -35,7 +35,7 @@ import org.apache.commons.lang3.reflect.MethodUtils
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.auron.util.Using
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Abs, Acos, Add, Alias, And, Asin, Atan, Attribute, AttributeReference, BitwiseAnd, BitwiseOr, BoundReference, CaseWhen, Cast, Ceil, CheckOverflow, Coalesce, Concat, ConcatWs, Contains, Cos, CreateArray, CreateNamedStruct, DayOfMonth, Divide, EndsWith, EqualTo, Exp, Expression, Floor, GetArrayItem, GetJsonObject, GetMapValue, GetStructField, GreaterThan, GreaterThanOrEqual, If, In, InSet, IsNotNull, IsNull, LeafExpression, Length, LessThan, LessThanOrEqual, Like, Literal, Log, Log10, Log2, Lower, MakeDecimal, Md5, Month, Multiply, Murmur3Hash, Not, NullIf, OctetLength, Or, Remainder, Sha2, ShiftLeft, ShiftRight, Signum, Sin, Sqrt, StartsWith, StringRepeat, StringSpace, StringTrim, StringTrimLeft, StringTrimRight, Substring, Subtract, Tan, Unevaluable, UnscaledValue, Upper, XxHash64, Year}
+import org.apache.spark.sql.catalyst.expressions.{Abs, Acos, Add, Alias, And, Asin, Atan, Attribute, AttributeReference, BitwiseAnd, BitwiseOr, BoundReference, CaseWhen, Cast, Ceil, CheckOverflow, Coalesce, Concat, ConcatWs, Contains, Cos, CreateArray, CreateNamedStruct, DayOfMonth, Divide, EndsWith, EqualTo, Exp, Expm1, Expression, Factorial, Floor, GetArrayItem, GetJsonObject, GetMapValue, GetStructField, GreaterThan, GreaterThanOrEqual, Hex, If, In, InSet, IsNotNull, IsNull, LeafExpression, Length, LessThan, LessThanOrEqual, Like, Literal, Log, Log10, Log2, Lower, MakeDecimal, Md5, Month, Multiply, Murmur3Hash, Not, NullIf, OctetLength, Or, Remainder, Sha2, ShiftLeft, ShiftRight, Signum, Sin, Sqrt, StartsWith, StringRepeat, StringSpace, StringTrim, StringTrimLeft, StringTrimRight, Substring, Subtract, Tan, Unevaluable, UnscaledValue, Upper, XxHash64, Year}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, Average, CollectList, CollectSet, Count, DeclarativeAggregate, First, Max, Min, Sum, TypedImperativeAggregate}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.expressions.codegen.ExprCode
@@ -799,6 +799,10 @@ object NativeConverters extends Logging {
                 .build())
           }
         }
+      case e: Expm1 => buildScalarFunction(pb.ScalarFunction.Expm1, e.children, e.dataType)
+      case e: Factorial =>
+        buildScalarFunction(pb.ScalarFunction.Factorial, e.children, e.dataType)
+      case e: Hex => buildScalarFunction(pb.ScalarFunction.Hex, e.children, e.dataType)
 
       // TODO: datafusion's round() has different behavior from spark
       // case e @ Round(_1, Literal(n: Int, _)) if _1.dataType.isInstanceOf[FractionalType] =>


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1214.

 # Rationale for this change

The `datafusion-spark` crate provides spark-compatible expressions, which I would like to introduce in auron. Currently, it has some implementations, and I will try to extend auron native scalar functions based on its.

# What changes are included in this PR?

+ introduce datafusion-spark crate
+ support `expm1/factorial/hex` scalar functions;

# Are there any user-facing changes?

yes, new supported native functions

# How was this patch tested?

added test case
